### PR TITLE
Provide information if a target is a test target

### DIFF
--- a/Sources/DependencyCalculator/PackageMetadata.swift
+++ b/Sources/DependencyCalculator/PackageMetadata.swift
@@ -13,6 +13,7 @@ struct PackageTargetMetadata {
     let affectedBy: Set<Path>
     let name: String
     let dependsOn: Set<TargetIdentity>
+    let testTarget: Bool
     
     // TODO: Split in several methods
     static func parse(at path: Path) throws -> [PackageTargetMetadata] {
@@ -58,15 +59,15 @@ struct PackageTargetMetadata {
                        let depPackageName = product[1] as? String,
                        let depPath = filesystemDeps[depPackageName.lowercased()] {
                         
-                        return TargetIdentity.swiftPackage(path: depPath, name: depTarget)
+                        return TargetIdentity.package(path: depPath, name: depTarget, testTarget: false)
                     }
                     else if let byName = dependencyDescription["byName"] as? [Any],
                             let depName = byName[0] as? String {
                         if let depPath = filesystemDeps[depName.lowercased()] {
-                            return TargetIdentity.swiftPackage(path: depPath, name: depName)
+                            return TargetIdentity.package(path: depPath, name: depName, testTarget: false)
                         }
                         else {
-                            return TargetIdentity.swiftPackage(path: path, name: depName)
+                            return TargetIdentity.package(path: path, name: depName, testTarget: false)
                         }
                     }
                     else {
@@ -125,11 +126,12 @@ struct PackageTargetMetadata {
             return PackageTargetMetadata(path: path,
                                          affectedBy: affectedBy,
                                          name: targetName,
-                                         dependsOn: Set(dependencies))
+                                         dependsOn: Set(dependencies),
+                                         testTarget: type == "test")
         }
     }
     
     func targetIdentity() -> TargetIdentity {
-        return TargetIdentity.swiftPackage(path: path, name: name)
+        return TargetIdentity.package(path: path, name: name, testTarget: testTarget)
     }
 }

--- a/Sources/SelectiveTestingCore/SelectiveTestingTool.swift
+++ b/Sources/SelectiveTestingCore/SelectiveTestingTool.swift
@@ -90,10 +90,10 @@ public final class SelectiveTestingTool {
                 .allTargets()
                 .sorted(by: { $0.description < $1.description }).forEach { target in
                 switch target {
-                case .swiftPackage(let path, let name):
+                case .package(let path, let name, _):
                     Logger.message("Package target at \(path): \(name) depends on:")
 
-                case .target(let projectPath, let name):
+                case .project(let projectPath, let name, _):
                     Logger.message("Project target at \(projectPath): \(name) depends on:")
                 }
                 
@@ -146,20 +146,21 @@ public final class SelectiveTestingTool {
     private func printJSON(affectedTargets: Set<TargetIdentity>) throws {
         struct TargetIdentitySerialization: Encodable {
             enum TargetType: String, Encodable {
-                case swiftPackage
+                case packageTarget
                 case target
             }
             let name: String
             let type: TargetType
             let path: String
+            let testTarget: Bool
         }
         
         let array = Array(affectedTargets.map { target in
             switch target {
-            case .swiftPackage(let path, let name):
-                return TargetIdentitySerialization(name: name, type: .swiftPackage, path: path.string)
-            case .target(let path, let name):
-                return TargetIdentitySerialization(name: name, type: .target, path: path.string)
+            case .package(let path, let name, let testTarget):
+                return TargetIdentitySerialization(name: name, type: .packageTarget, path: path.string, testTarget: testTarget)
+            case .project(let path, let name, let testTarget):
+                return TargetIdentitySerialization(name: name, type: .target, path: path.string, testTarget: testTarget)
             }
         })
         

--- a/Sources/TestConfigurator/TestConfigurator.swift
+++ b/Sources/TestConfigurator/TestConfigurator.swift
@@ -14,18 +14,18 @@ extension TestPlanHelper {
         
         let packagesToTest = Set<String>(targets.compactMap { target in
             switch target {
-            case .swiftPackage(_, let name):
+            case .package(_, let name, _):
                 return name
-            case .target(_, _):
+            case .project(_, _, _):
                 return nil
             }
         })
         
         let targetsToTest = Set<String>(targets.compactMap { target in
             switch target {
-            case .swiftPackage(_, _):
+            case .package(_, _, _):
                 return nil
-            case .target(_, let name):
+            case .project(_, let name, _):
                 return name
             }
         })

--- a/Sources/Workspace/Target.swift
+++ b/Sources/Workspace/Target.swift
@@ -6,34 +6,54 @@ import Foundation
 import XcodeProj
 import PathKit
 
-public enum TargetIdentity: Hashable {
+extension PBXNativeTarget {
+    var isTestTarget: Bool {
+        switch self.productType {
+        case .unitTestBundle, .uiTestBundle, .ocUnitTestBundle:
+            return true
+        default:
+            return false
+        }
+    }
+}
 
-    case target(projectPath: Path, name: String)
-    case swiftPackage(path: Path, name: String)
+public enum TargetIdentity: Hashable {
+    
+    case project(projectPath: Path, name: String, testTarget: Bool)
+    case package(path: Path, name: String, testTarget: Bool)
     
     public init(projectPath: Path, target: PBXNativeTarget) {
-        self = .target(projectPath: projectPath, name: target.name)
+        self = .project(projectPath: projectPath, name: target.name, testTarget: target.isTestTarget)
     }
     
-    public init(projectPath: Path, targetName: String) {
-        self = .target(projectPath: projectPath, name: targetName)
+    public init(projectPath: Path, targetName: String, testTarget: Bool) {
+        self = .project(projectPath: projectPath, name: targetName, testTarget: testTarget)
     }
     
     public var path: Path {
         switch self {
-        case .swiftPackage(let path, _):
+        case .package(let path, _, _):
             return path
-        case .target(let path, _):
+        case .project(let path, _, _):
             return path
         }
     }
     
     public var isProject: Bool {
         switch self {
-        case .target(_, _):
+        case .project(_, _, _):
             return true
-        case .swiftPackage(_, _):
+        case .package(_, _, _):
             return false
+        }
+    }
+    
+    public var isTestTarget: Bool {
+        switch self {
+        case .project(_, _, let test):
+            return test
+        case .package(_, _, let test):
+            return test
         }
     }
 }
@@ -41,9 +61,9 @@ public enum TargetIdentity: Hashable {
 extension TargetIdentity: CustomStringConvertible {
     public var description: String {
         switch self {
-        case .target(let projectPath, let name):
+        case .project(let projectPath, let name, _):
             return "\(projectPath.lastComponentWithoutExtension):\(name)"
-        case .swiftPackage(let packagePath, let name):
+        case .package(let packagePath, let name, _):
             return "\(packagePath.lastComponentWithoutExtension):\(name)"
         }
     }
@@ -54,9 +74,9 @@ extension TargetIdentity {
     
     public var configIdentity: String {
         switch self {
-        case .target(let projectPath, let name):
+        case .project(let projectPath, let name, _):
             return "\(projectPath.lastComponentWithoutExtension):\(name)"
-        case .swiftPackage(let packagePath, let name):
+        case .package(let packagePath, let name, _):
             return "\(packagePath.lastComponentWithoutExtension):\(name)"
         }
     }

--- a/Tests/DependencyCalculatorTests/DependencyCalculatorTests.swift
+++ b/Tests/DependencyCalculatorTests/DependencyCalculatorTests.swift
@@ -12,14 +12,14 @@ import SelectiveTestingCore
 final class DependencyCalculatorTests: XCTestCase {
     
     func depStructure() -> (DependencyGraph, TargetIdentity, TargetIdentity, TargetIdentity, TargetIdentity, TargetIdentity, TargetIdentity) {
-        let mainApp = TargetIdentity.target(projectPath: "/folder/Project.xcodepoj", name: "MainApp")
-        let mainAppTests = TargetIdentity.target(projectPath: "/folder/Project.xcodepoj", name: "MainAppTests")
+        let mainApp = TargetIdentity.project(projectPath: "/folder/Project.xcodepoj", name: "MainApp", testTarget: false)
+        let mainAppTests = TargetIdentity.project(projectPath: "/folder/Project.xcodepoj", name: "MainAppTests", testTarget: true)
         
-        let module = TargetIdentity.target(projectPath: "/folder/Project.xcodepoj", name: "Module")
-        let moduleTests = TargetIdentity.target(projectPath: "/folder/Project.xcodepoj", name: "ModuleTest")
+        let module = TargetIdentity.project(projectPath: "/folder/Project.xcodepoj", name: "Module", testTarget: false)
+        let moduleTests = TargetIdentity.project(projectPath: "/folder/Project.xcodepoj", name: "ModuleTest", testTarget: true)
         
-        let submodule = TargetIdentity.target(projectPath: "/folder/Project.xcodepoj", name: "SubModule")
-        let submoduleTests = TargetIdentity.target(projectPath: "/folder/Project.xcodepoj", name: "SubModuleTest")
+        let submodule = TargetIdentity.project(projectPath: "/folder/Project.xcodepoj", name: "SubModule", testTarget: false)
+        let submoduleTests = TargetIdentity.project(projectPath: "/folder/Project.xcodepoj", name: "SubModuleTest", testTarget: true)
         
         var depGraph: [TargetIdentity: Set<TargetIdentity>] = [:]
         

--- a/Tests/DependencyCalculatorTests/PackageMetadataTests.swift
+++ b/Tests/DependencyCalculatorTests/PackageMetadataTests.swift
@@ -32,9 +32,10 @@ final class PackageMetadataTests: XCTestCase {
         XCTAssertEqual(second.dependsOn.count, 1)
         XCTAssertEqual(second.affectedBy, Set([basePath + "Package.swift", basePath + "Tests" + "ExampleSubpackageTests"]))
 
-        if case let TargetIdentity.swiftPackage(path, name) = try XCTUnwrap(second.dependsOn.first) {
+        if case let TargetIdentity.package(path, name, test) = try XCTUnwrap(second.dependsOn.first) {
             XCTAssertEqual(path, basePath)
             XCTAssertEqual(name, "ExampleSubpackage")
+            XCTAssertFalse(test)
         }
         else {
             XCTFail()
@@ -55,7 +56,7 @@ final class PackageMetadataTests: XCTestCase {
         let first = metadata[0]
         XCTAssertEqual(first.name, "SelectiveTesting")
         XCTAssertEqual(first.path, basePath)
-        XCTAssertEqual(first.dependsOn, Set([TargetIdentity.swiftPackage(path: basePath, name: "SelectiveTestingCore")]))
+        XCTAssertEqual(first.dependsOn, Set([TargetIdentity.package(path: basePath, name: "SelectiveTestingCore", testTarget: false)]))
         XCTAssertEqual(first.affectedBy, Set([basePath + "Package.swift", basePath + "Sources" + "SelectiveTesting"]))
         
         let second = metadata[1]

--- a/Tests/SelectiveTestingTests/IntegrationTestTool.swift
+++ b/Tests/SelectiveTestingTests/IntegrationTestTool.swift
@@ -97,26 +97,26 @@ final class IntegrationTestTool {
             }
             
             if container.extension == "xcworkspace" || container.extension == "xcodeproj" {
-                return TargetIdentity.target(projectPath: projectPath + container, name: name)
+                return TargetIdentity.project(projectPath: projectPath + container, name: name, testTarget: true)
             }
             else {
-                return TargetIdentity.swiftPackage(path: projectPath + container, name: name)
+                return TargetIdentity.package(path: projectPath + container, name: name, testTarget: true)
             }
         }
         
         XCTAssertEqual(Set(testPlanTargets), expected)
     }
     
-    lazy var mainProjectMainTarget = TargetIdentity(projectPath: projectPath + "ExampleProject.xcodeproj", targetName: "ExampleProject")
-    lazy var mainProjectTests = TargetIdentity(projectPath: projectPath + "ExampleProject.xcodeproj", targetName: "ExampleProjectTests")
-    lazy var mainProjectLibrary = TargetIdentity(projectPath: projectPath + "ExampleProject.xcodeproj", targetName: "ExmapleTargetLibrary")
-    lazy var mainProjectLibraryTests = TargetIdentity(projectPath: projectPath + "ExampleProject.xcodeproj", targetName: "ExmapleTargetLibraryTests")
-    lazy var mainProjectUITests = TargetIdentity(projectPath: projectPath + "ExampleProject.xcodeproj", targetName: "ExampleProjectUITests")
-    lazy var exampleLibrary = TargetIdentity(projectPath: projectPath + "ExampleLibrary/ExampleLibrary.xcodeproj", targetName: "ExampleLibrary")
-    lazy var exampleLibraryTests = TargetIdentity(projectPath: projectPath + "ExampleLibrary/ExampleLibrary.xcodeproj", targetName: "ExampleLibraryTests")
-    lazy var package = TargetIdentity.swiftPackage(path: projectPath + "ExamplePackage", name: "ExamplePackage")
-    lazy var packageTests = TargetIdentity.swiftPackage(path: projectPath + "ExamplePackage", name: "ExamplePackageTests")
-    lazy var subtests = TargetIdentity.swiftPackage(path: projectPath + "ExamplePackage", name: "Subtests")
-    lazy var binary = TargetIdentity.swiftPackage(path: projectPath + "ExamplePackage", name: "BinaryTarget")
+    lazy var mainProjectMainTarget = TargetIdentity(projectPath: projectPath + "ExampleProject.xcodeproj", targetName: "ExampleProject", testTarget: false)
+    lazy var mainProjectTests = TargetIdentity(projectPath: projectPath + "ExampleProject.xcodeproj", targetName: "ExampleProjectTests", testTarget: true)
+    lazy var mainProjectLibrary = TargetIdentity(projectPath: projectPath + "ExampleProject.xcodeproj", targetName: "ExmapleTargetLibrary", testTarget: false)
+    lazy var mainProjectLibraryTests = TargetIdentity(projectPath: projectPath + "ExampleProject.xcodeproj", targetName: "ExmapleTargetLibraryTests", testTarget: true)
+    lazy var mainProjectUITests = TargetIdentity(projectPath: projectPath + "ExampleProject.xcodeproj", targetName: "ExampleProjectUITests", testTarget: true)
+    lazy var exampleLibrary = TargetIdentity(projectPath: projectPath + "ExampleLibrary/ExampleLibrary.xcodeproj", targetName: "ExampleLibrary", testTarget: false)
+    lazy var exampleLibraryTests = TargetIdentity(projectPath: projectPath + "ExampleLibrary/ExampleLibrary.xcodeproj", targetName: "ExampleLibraryTests", testTarget: true)
+    lazy var package = TargetIdentity.package(path: projectPath + "ExamplePackage", name: "ExamplePackage", testTarget: false)
+    lazy var packageTests = TargetIdentity.package(path: projectPath + "ExamplePackage", name: "ExamplePackageTests", testTarget: true)
+    lazy var subtests = TargetIdentity.package(path: projectPath + "ExamplePackage", name: "Subtests", testTarget: true)
+    lazy var binary = TargetIdentity.package(path: projectPath + "ExamplePackage", name: "BinaryTarget", testTarget: false)
 
 }


### PR DESCRIPTION
For certain use cases it might be useful to know if a given target is a test target. 

For example, xcodebuild is not happy when asked to run tests for non-test target.