### PR TITLE
Fix SPM assets path calculation, add new XCLocalSwiftPackageReference

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -50,8 +50,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/tuist/XcodeProj.git",
       "state" : {
-        "revision" : "fae27b48bc14ff3fd9b02902e48c4665ce5a0793",
-        "version" : "8.9.0"
+        "revision" : "8b5b4cff9d750b087081c569870baa6b451a0b30"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -50,7 +50,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/tuist/XcodeProj.git",
       "state" : {
-        "revision" : "8b5b4cff9d750b087081c569870baa6b451a0b30"
+        "revision" : "447c159b0c5fb047a024fd8d942d4a76cf47dde0",
+        "version" : "8.16.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -76,7 +76,7 @@ let package = Package(
     ],
     products: products,
     dependencies: [
-        .package(url: "https://github.com/tuist/XcodeProj.git", revision: "8b5b4cff9d750b087081c569870baa6b451a0b30"),
+        .package(url: "https://github.com/tuist/XcodeProj.git", .upToNextMajor(from: "8.16.0")),
         .package(url: "https://github.com/apple/swift-argument-parser.git", .upToNextMajor(from: "1.2.0")),
         .package(url: "https://github.com/kylef/PathKit.git", .upToNextMinor(from: "1.0.0")),
         .package(url: "https://github.com/onevcat/Rainbow", .upToNextMajor(from: "4.0.0")),

--- a/Package.swift
+++ b/Package.swift
@@ -76,7 +76,7 @@ let package = Package(
     ],
     products: products,
     dependencies: [
-        .package(url: "https://github.com/tuist/XcodeProj.git", .upToNextMajor(from: "8.9.0")),
+        .package(url: "https://github.com/tuist/XcodeProj.git", revision: "8b5b4cff9d750b087081c569870baa6b451a0b30"),
         .package(url: "https://github.com/apple/swift-argument-parser.git", .upToNextMajor(from: "1.2.0")),
         .package(url: "https://github.com/kylef/PathKit.git", .upToNextMinor(from: "1.0.0")),
         .package(url: "https://github.com/onevcat/Rainbow", .upToNextMajor(from: "4.0.0")),

--- a/Sources/DependencyCalculator/DependencyGraph.swift
+++ b/Sources/DependencyCalculator/DependencyGraph.swift
@@ -41,7 +41,7 @@ extension WorkspaceInfo {
         
         let includeRootPackage = !Set(["xcworkspace", "xcodeproj"]).contains(path.extension)
         
-        let (packageWorkspaceInfo, packages) = try parsePackages(in: path, includeRootPackage: includeRootPackage, exclude: exclude)
+        var (packageWorkspaceInfo, packages) = try parsePackages(in: path, includeRootPackage: includeRootPackage, exclude: exclude)
         
         var resultDependencies = packageWorkspaceInfo.dependencyStructure
         var files = packageWorkspaceInfo.files
@@ -67,7 +67,7 @@ extension WorkspaceInfo {
         try allProjects.forEach { (project, projectPath) in
             let newDependencies = try parseProject(from: project,
                                                    path: projectPath,
-                                                   packages: packages,
+                                                   packages: &packages,
                                                    allProjects: allProjects)
             resultDependencies = resultDependencies.merging(with: newDependencies.dependencyStructure)
             
@@ -224,7 +224,7 @@ extension WorkspaceInfo {
     
     static func parseProject(from project: XcodeProj,
                              path: Path,
-                             packages: [PackageTargetMetadata],
+                             packages: inout [PackageTargetMetadata],
                              allProjects: [(XcodeProj, Path)]) throws -> WorkspaceInfo {
         
         var dependsOn: [TargetIdentity: Set<TargetIdentity>] = [:]
@@ -232,9 +232,21 @@ extension WorkspaceInfo {
         var folders: [Path: TargetIdentity] = [:]
         var candidateTestPlan: String? = nil
         
-        let packagesByName: [String: PackageTargetMetadata] = packages.toDictionary(path: \.name)
-
+        var packagesByName: [String: PackageTargetMetadata] = packages.toDictionary(path: \.name)
         let targetsByName = project.pbxproj.nativeTargets.toDictionary(path: \.name)
+        
+        project.pbxproj.rootObject?.localPackages.forEach { localPackage in
+            let absolutePath = path.parent() + localPackage.relativePath
+            
+            guard let newPackages = try? PackageTargetMetadata.parse(at: absolutePath) else {
+                Logger.warning("Cannot find local package at \(absolutePath)")
+                return
+            }
+            newPackages.forEach { package in
+                packagesByName[package.name] = package
+                packages.append(package)
+            }
+        }
         
         try project.pbxproj.nativeTargets.forEach { target in
             let targetIdentity = TargetIdentity(projectPath: path, target: target)

--- a/Sources/DependencyCalculator/PackageMetadata.swift
+++ b/Sources/DependencyCalculator/PackageMetadata.swift
@@ -105,7 +105,7 @@ struct PackageTargetMetadata {
             if let resources = target["resources"] as? [[String: Any]] {
                 resources.forEach { resource in
                     if let resourcePath = resource["path"] as? String {
-                        affectedBy.insert(targetRootPath + resourcePath)
+                        affectedBy.insert(targetRootPath + targetName + resourcePath)
                     }
                 }
             }

--- a/Tests/DependencyCalculatorTests/ExamplePackages/Simple/Package.swift
+++ b/Tests/DependencyCalculatorTests/ExamplePackages/Simple/Package.swift
@@ -20,7 +20,9 @@ let package = Package(
         // Targets can depend on other targets in this package, and on products in packages this package depends on.
         .target(
             name: "ExampleSubpackage",
-            dependencies: []),
+            dependencies: [],
+            resources: [.process("Assets.xcassets")]
+        ),
         .testTarget(
             name: "ExampleSubpackageTests",
             dependencies: ["ExampleSubpackage"]),

--- a/Tests/DependencyCalculatorTests/PackageMetadataTests.swift
+++ b/Tests/DependencyCalculatorTests/PackageMetadataTests.swift
@@ -24,7 +24,9 @@ final class PackageMetadataTests: XCTestCase {
         XCTAssertEqual(first.name, "ExampleSubpackage")
         XCTAssertEqual(first.path, basePath)
         XCTAssertEqual(first.dependsOn.count, 0)
-        XCTAssertEqual(first.affectedBy, Set([basePath + "Package.swift", basePath + "Sources" + "ExampleSubpackage"]))
+        XCTAssertEqual(first.affectedBy, Set([basePath + "Package.swift",
+                                              basePath + "Sources" + "ExampleSubpackage",
+                                              basePath + "Sources" + "ExampleSubpackage" + "Assets.xcassets"]))
 
         let second = metadata[1]
         XCTAssertEqual(second.name, "ExampleSubpackageTests")

--- a/Tests/SelectiveTestingTests/ExampleProject/ExampleSubpackage/Package.swift
+++ b/Tests/SelectiveTestingTests/ExampleProject/ExampleSubpackage/Package.swift
@@ -20,7 +20,8 @@ let package = Package(
         // Targets can depend on other targets in this package, and on products in packages this package depends on.
         .target(
             name: "ExampleSubpackage",
-            dependencies: []),
+            dependencies: []
+        ),
         .testTarget(
             name: "ExampleSubpackageTests",
             dependencies: ["ExampleSubpackage"]),


### PR DESCRIPTION
I noticed in Xcode 15 SPM support was improved with introduction of XCLocalSwiftPackageReference.

Additionally, with some warnings I've seen that the assets path for some SPM packages was not calculated correctly.

Requires https://github.com/tuist/XcodeProj/issues/804