### PR TITLE
remove do catch

### DIFF
--- a/Sources/xcode-selective-test/SelectiveTesting.swift
+++ b/Sources/xcode-selective-test/SelectiveTesting.swift
@@ -39,11 +39,6 @@ struct SelectiveTesting: AsyncParsableCommand {
                                             renderDependencyGraph: dependencyGraph,
                                             dot: dot,
                                             verbose: verbose)
-
-        do {
-            let _ = try await tool.run()
-        } catch {
-            Logger.error("\(error)")
-        }
+        let _ = try await tool.run()
     }
 }


### PR DESCRIPTION
This removes the `do catch` around the` tool.run` command.

This was allowing the tool to fail silently on the CI and then the workflow step only ends when it timed out. 

If the error is actually thrown, the process will exit with an error code instead.