### PR TITLE
Match implicit dependencies when productNameWithExtension() is not correct

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -50,8 +50,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/tuist/XcodeProj.git",
       "state" : {
-        "revision" : "447c159b0c5fb047a024fd8d942d4a76cf47dde0",
-        "version" : "8.16.0"
+        "revision" : "313aaf1ad612135b7b0ccf731c86b5c07bf149b5",
+        "version" : "8.20.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -81,7 +81,7 @@ let package = Package(
     ],
     products: products,
     dependencies: [
-        .package(url: "https://github.com/tuist/XcodeProj.git", .upToNextMajor(from: "8.16.0")),
+        .package(url: "https://github.com/tuist/XcodeProj.git", .upToNextMajor(from: "8.20.0")),
         .package(url: "https://github.com/apple/swift-argument-parser.git", .upToNextMajor(from: "1.2.0")),
         .package(url: "https://github.com/kylef/PathKit.git", .upToNextMinor(from: "1.0.0")),
         .package(url: "https://github.com/onevcat/Rainbow", .upToNextMajor(from: "4.0.0")),


### PR DESCRIPTION
Discovered this bug when testing integration with [Wire-iOS](https://github.com/wireapp/wire-ios) for fun:

Some targets, for example WireCanvas return Canvas.framework from `productNameWithExtension()`. 

This is a workaround until https://github.com/tuist/XcodeProj/issues/820 is fixed