### PR TITLE
Support artifact bundle for macOS

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,45 @@
+name: Release
+
+on:
+  workflow_dispatch:
+  release:
+    types: [published]
+  push:
+    branches:
+        - arifactbundle
+
+jobs:
+  build:
+    name: Build for macos-universal
+    runs-on: macos-14
+    steps:
+    - uses: swift-actions/setup-swift@v2
+      with:
+        swift-version: "5.10"
+    - uses: actions/checkout@v4
+    - name: Install the binary
+      run: ./install.sh
+    - name: Upload the binary
+      uses: actions/upload-artifact@v4
+      with:
+        path: xcode-selective-test.tar.gz
+        name: xcode-selective-test
+
+  check-portability:
+    needs: build
+    name: TestRun on ${{ matrix.destination.os }} for macos-universal
+    runs-on: ${{ matrix.destination.os }}
+    strategy:
+      matrix:
+        destination:
+          - { os: macos-14 }
+          - { os: macos-13 }
+          - { os: macos-12 }
+    steps:
+    - uses: actions/download-artifact@v4
+      with:
+        name: xcode-selective-test
+    - name: Unpack the binary
+      run: tar -xvf xcode-selective-test.tar.gz
+    - name: Run the binary
+      run: ./xcode-selective-test -h

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,9 +4,6 @@ on:
   workflow_dispatch:
   release:
     types: [published]
-  push:
-    branches:
-        - arifactbundle
 
 jobs:
   build:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,3 +40,48 @@ jobs:
       run: tar -xvf xcode-selective-test.tar.gz
     - name: Run the binary
       run: ./xcode-selective-test -h
+       
+  make-artifact-bundle:
+    needs: [build, check-portability]
+    runs-on: ubuntu-latest
+    outputs:
+      checksum: ${{ steps.checksum.outputs.checksum }}
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/download-artifact@v4
+      with:
+        name: xcode-selective-test
+    - run: ./spm-artifact-bundle.sh ${{ github.event.release.tag_name || github.ref_name }}
+    - name: Upload artifact bundle
+      uses: actions/upload-artifact@v4
+      with:
+        name: xcode-selective-test.artifactbundle.zip
+        path: xcode-selective-test.artifactbundle.zip
+    - name: Compute checksum
+      id: checksum
+      run: echo "checksum=$(swift package compute-checksum xcode-selective-test.artifactbundle.zip)" >> "$GITHUB_OUTPUT"
+    
+  deploy-binary:
+    if: ${{ github.event_name == 'release' }}
+    needs: [check-portability, make-artifact-bundle]
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/download-artifact@v4
+      with:
+        merge-multiple: true
+    - name: Deploy the binary
+      uses: softprops/action-gh-release@v2
+      with:
+        body: |
+          ### Binary artifactbundle 
+          ```swift
+          .binaryTarget(
+            name: "xcode-selective-test",
+            url: "https://github.com/${{ github.repository }}/releases/download/${{ github.event.release.tag_name }}/xcode-selective-test.artifactbundle.zip",
+            checksum: "${{ needs.make-artifact-bundle.outputs.checksum }}"
+          )
+          ```
+        append_body: true
+        files: |
+          xcode-selective-test.tar.gz
+          xcode-selective-test.artifactbundle.zip

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,17 @@
+#!/bin/bash -e
+
+CUR=$PWD
+
+# Build for macOS universal
+echo "** Clean/Build..."
+rm -rf .build
+swift build -c release --arch arm64 --arch x86_64
+
+echo "** Install..."
+cd .build/apple/Products/Release
+tar -cvzf xcode-selective-test.tar.gz xcode-selective-test
+mv xcode-selective-test.tar.gz "$CUR"
+
+cd "$CUR"
+echo "** Output file is xcode-selective-test.tar.gz"
+echo "** Done."

--- a/spm-artifact-bundle-info.template
+++ b/spm-artifact-bundle-info.template
@@ -1,0 +1,15 @@
+{
+    "schemaVersion": "1.0",
+    "artifacts": {
+        "xcode-selective-test": {
+            "version": "__VERSION__",
+            "type": "executable",
+            "variants": [
+                {
+                    "path": "xcode-selective-test/bin/xcode-selective-test",
+                    "supportedTriples": ["x86_64-apple-macosx", "arm64-apple-macosx"]
+                }
+            ]
+        }
+    }
+}

--- a/spm-artifact-bundle.sh
+++ b/spm-artifact-bundle.sh
@@ -1,0 +1,30 @@
+#!/bin/bash -e
+
+VERSION=$1
+ARTIFACT_BUNDLE=xcode-selective-test.artifactbundle
+
+usage() {
+    echo "[Usage] $0 <VERSION>"
+}
+
+if [ "$VERSION" = "" ]; then
+    usage
+    echo "VERSION is required"
+    exit 1
+fi
+
+echo "** Zip artifact bundle..."
+
+rm -rf $ARTIFACT_BUNDLE
+mkdir $ARTIFACT_BUNDLE
+
+mkdir -p $ARTIFACT_BUNDLE/xcode-selective-test/bin
+tar -xzf xcode-selective-test.tar.gz -C $ARTIFACT_BUNDLE/xcode-selective-test/bin
+
+sed 's/__VERSION__/'"${VERSION}"'/g' spm-artifact-bundle-info.template > "${ARTIFACT_BUNDLE}/info.json"
+cp LICENSE ACKNOWLEDGEMENTS $ARTIFACT_BUNDLE
+
+zip -yr - $ARTIFACT_BUNDLE > "${ARTIFACT_BUNDLE}.zip"
+rm -rf $ARTIFACT_BUNDLE
+
+echo "** Done."


### PR DESCRIPTION
Thank you for your wonderful tool.

When we use it in our project, our primary usage is in CI. In that case, we encountered the following issues:
- When used with [XcodeGen](https://github.com/yonaskolb/XcodeGen), dependency resolution fails due to incompatible [XcodeProj](https://github.com/tuist/XcodeProj) versions.
- Since it’s not a binary target, the build runs at execution time, which takes additional time.

To solve these issues, I would like to support artifact bundles. This will allow us to use pre-built binaries, thereby resolving dependency issues and eliminating the build time during execution.

To specify a binaryTarget in an existing Command Plugin, a checksum is required, which in turn necessitates the generation of an artifact bundle. Implementing all of this in a single repository would make the release flow too complex. Therefore, in this PR, I aim to support the generation of artifact bundles.

For practical use, it might be more manageable to create a separate repository, similar to https://github.com/SwiftGen/SwiftGenPlugin.

- Discussions:
  - https://github.com/realm/SwiftLint/pull/4603#discussion_r1034266506 
- References:
  - https://github.com/apple/swift-evolution/blob/main/proposals/0305-swiftpm-binary-target-improvements.md
  - https://github.com/apple/swift-evolution/blob/main/proposals/0303-swiftpm-extensible-build-tools.md