### PR TITLE
fix(19): Use also staged changes for calculating affected targets

### DIFF
--- a/Sources/Git/Git+Changeset.swift
+++ b/Sources/Git/Git+Changeset.swift
@@ -36,7 +36,8 @@ public extension Git {
     func localChangeset() throws -> Set<Path> {
         let gitRoot = try repoRoot()
 
-        let changes = try Shell.execOrFail("cd \(gitRoot) && git diff --name-only")
+        let changes = try Shell.execOrFail("cd \(gitRoot) && git diff HEAD --name-only")
+        
         let changesTrimmed = changes.trimmingCharacters(in: .whitespacesAndNewlines)
 
         guard !changesTrimmed.isEmpty else {


### PR DESCRIPTION
Found a better way to take into account both staged and unstaged files when calculating targets affected:

https://stackoverflow.com/questions/13057457/show-both-staged-working-tree-in-git-diff
