### PR TITLE
feat: Add support of maximumTestExecutionTimeAllowance in Testplan

### DIFF
--- a/Sources/TestConfigurator/xctestplanner/Core/Entity/TestPlanModel.swift
+++ b/Sources/TestConfigurator/xctestplanner/Core/Entity/TestPlanModel.swift
@@ -39,6 +39,7 @@ public struct DefaultOptions: Codable {
     public var testTimeoutsEnabled: Bool?
     public var testRepetitionMode: String?
     public var maximumTestRepetitions: Int?
+    public var maximumTestExecutionTimeAllowance: Int?
 }
 
 // MARK: - CommandLineArgumentEntry


### PR DESCRIPTION
Add support of maximumTestExecutionTimeAllowance for `.xctestplan` file.


When this tool updates or creates the `.xctestplan` file, it does not copy the `maximumTestExecutionTimeAllowance` value from the original file.