### PR TITLE
Update dependency tuist/XcodeProj to 8.24.2

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -50,8 +50,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/tuist/XcodeProj.git",
       "state" : {
-        "revision" : "babd2491ea34777bec9d33381a60cd782559b4b3",
-        "version" : "8.24.1"
+        "revision" : "0b5e5a80e4357bf27bf1ba28879896a7d965a092",
+        "version" : "8.24.2"
       }
     },
     {


### PR DESCRIPTION
In some projects, a DecodingError caused by XcodeProj occurs. 
```
Error: typeMismatch(Swift.Int, Swift.DecodingError.Context(codingPath: [CodingKeys(stringValue: "preferredProjectObjectVersion", intValue: nil)], debugDescription: "Expected to decode Int but found a string instead.", underlyingError: nil))
```
It seems that at least version [8.24.2](https://github.com/tuist/XcodeProj/releases/tag/8.24.2) is required to fix this issue.

### References
- https://github.com/tuist/XcodeProj/issues/861
- https://github.com/tuist/XcodeProj/pull/862