### PR TITLE
Bugfix: Change path used in git command to gitroot

### DIFF
--- a/Sources/Git/Git+Changeset.swift
+++ b/Sources/Git/Git+Changeset.swift
@@ -23,7 +23,7 @@ public extension Git {
             currentBranch = "HEAD"
         }
 
-        let changes = try Shell.execOrFail("cd \(path) && git diff '\(baseBranch)'..'\(currentBranch)' --name-only")
+        let changes = try Shell.execOrFail("cd \(gitRoot) && git diff '\(baseBranch)'..'\(currentBranch)' --name-only")
         let changesTrimmed = changes.trimmingCharacters(in: .whitespacesAndNewlines)
 
         guard !changesTrimmed.isEmpty else {


### PR DESCRIPTION
I noticed when running on a linux github runner I was getting odd results - the only changed file returned in the changeset was the project.pbxproj although I knew there should be other changes too. 

I think this is the cause - in this line:

 `let changes = try Shell.execOrFail("cd \(path) && git diff '\(baseBranch)'..'\(currentBranch)' --name-only")`

The directory changed  into (path) is actually the base-path - in this case the Xcode project. On github linux runner ` git diff '\(baseBranch)'..'\(currentBranch)' --name-only"` seems to return only changes below the current directory - hence only returning the project.pbxproj file and ignoring other changes. On mac it does seem to return all changes.

I think this should really be using the repo root though to avoid inconsistent behaviour on linux. (unsure if this is specifically a linux issue or due to git configuration on github runners)