### PR TITLE
Fix that defaultOptions.targetForVariableExpansion are not copied to generated test plan

### DIFF
--- a/Sources/TestConfigurator/xctestplanner/Core/Entity/TestPlanModel.swift
+++ b/Sources/TestConfigurator/xctestplanner/Core/Entity/TestPlanModel.swift
@@ -40,6 +40,7 @@ public struct DefaultOptions: Codable {
     public var testRepetitionMode: String?
     public var maximumTestRepetitions: Int?
     public var maximumTestExecutionTimeAllowance: Int?
+    public var targetForVariableExpansion: Target?
 }
 
 // MARK: - CommandLineArgumentEntry

--- a/Sources/TestConfigurator/xctestplanner/Core/Helper/TestPlanHelper.swift
+++ b/Sources/TestConfigurator/xctestplanner/Core/Helper/TestPlanHelper.swift
@@ -22,7 +22,7 @@ public class TestPlanHelper {
     static func writeTestPlan(_ testPlan: TestPlanModel, filePath: String) throws {
         Logger.message("Writing updated test plan to file: \(filePath)")
         let encoder = JSONEncoder()
-        encoder.outputFormatting = .prettyPrinted
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
         let updatedData = try encoder.encode(testPlan)
 
         let url = URL(fileURLWithPath: filePath)


### PR DESCRIPTION
This PR addresses an issue where the `defaultOptions.targetForVariableExpansion` entry was missing in the generated test plan. The fix implements the `targetForVariableExpansion` property in the `DefaultOptions` codable structure.

Additionally, this PR introduces the ".sortedKeys" output formatting to ensure consistent field ordering that matches Xcode's generated format. This enhancement simplifies comparison between original and generated test plans.