### PR TITLE
Handle spaces in project paths for git and package commands

### DIFF
--- a/Sources/DependencyCalculator/PackageMetadata.swift
+++ b/Sources/DependencyCalculator/PackageMetadata.swift
@@ -25,7 +25,7 @@ struct PackageTargetMetadata: Sendable {
             flags.append("--ignore-lock")
         }
 
-        let manifest = try Shell.execOrFail("(cd \(path) && swift package dump-package \(flags.joined(separator: " ")))")
+        let manifest = try Shell.execOrFail("(cd \(path.string.shellQuoted) && swift package dump-package \(flags.joined(separator: " ")))")
             .trimmingCharacters(in: .newlines)
         guard let manifestData = manifest.data(using: .utf8),
               let manifestJson = try JSONSerialization.jsonObject(with: manifestData, options: []) as? [String: Any],

--- a/Sources/Git/Git+Changeset.swift
+++ b/Sources/Git/Git+Changeset.swift
@@ -13,7 +13,7 @@ public extension Git {
     func changeset(baseBranch: String, verbose: Bool = false) throws -> Set<Path> {
         let gitRoot = try repoRoot()
 
-        var currentBranch = try Shell.execOrFail("(cd \(gitRoot) && git branch --show-current)").trimmingCharacters(in: .newlines)
+        var currentBranch = try Shell.execOrFail("(cd \(gitRoot.string.shellQuoted) && git branch --show-current)").trimmingCharacters(in: .newlines)
         if verbose {
             logger.info("Current branch: \(currentBranch)")
             logger.info("Base branch: \(baseBranch)")
@@ -25,7 +25,7 @@ public extension Git {
             currentBranch = "HEAD"
         }
 
-        let changes = try Shell.execOrFail("(cd \(gitRoot) && git diff '\(baseBranch)'..'\(currentBranch)' --name-only)")
+        let changes = try Shell.execOrFail("(cd \(gitRoot.string.shellQuoted) && git diff \(baseBranch.shellQuoted)..\(currentBranch.shellQuoted) --name-only)")
         let changesTrimmed = changes.trimmingCharacters(in: .whitespacesAndNewlines)
 
         guard !changesTrimmed.isEmpty else {
@@ -38,7 +38,7 @@ public extension Git {
     func localChangeset() throws -> Set<Path> {
         let gitRoot = try repoRoot()
 
-        let changes = try Shell.execOrFail("(cd \(gitRoot) && git diff HEAD --name-only)")
+        let changes = try Shell.execOrFail("(cd \(gitRoot.string.shellQuoted) && git diff HEAD --name-only)")
         
         let changesTrimmed = changes.trimmingCharacters(in: .whitespacesAndNewlines)
 

--- a/Sources/Git/Git.swift
+++ b/Sources/Git/Git.swift
@@ -14,7 +14,7 @@ public struct Git {
     }
 
     public func repoRoot() throws -> Path {
-        let gitPath = try Shell.execOrFail("(cd \(path) && git rev-parse --show-toplevel)").trimmingCharacters(in: .newlines)
+        let gitPath = try Shell.execOrFail("(cd \(path.string.shellQuoted) && git rev-parse --show-toplevel)").trimmingCharacters(in: .newlines)
 
         return Path(gitPath).absolute()
     }
@@ -22,7 +22,7 @@ public struct Git {
     public func find(pattern: String) throws -> Set<Path> {
         let gitRoot = try repoRoot()
 
-        let result = try Shell.exec("(cd \(gitRoot) && git ls-files | grep \(pattern))").0.trimmingCharacters(in: .newlines)
+        let result = try Shell.exec("(cd \(gitRoot.string.shellQuoted) && git ls-files | grep \(pattern.shellQuoted))").0.trimmingCharacters(in: .newlines)
 
         guard !result.isEmpty else {
             return Set()

--- a/Sources/SelectiveTestShell/String+Shell.swift
+++ b/Sources/SelectiveTestShell/String+Shell.swift
@@ -1,0 +1,13 @@
+//
+//  Created by Mike Gerasymenko <mike@gera.cx>
+//
+
+import Foundation
+
+public extension String {
+    /// Wrap string in single quotes for safe usage in shell commands.
+    var shellQuoted: String {
+        guard !isEmpty else { return "''" }
+        return "'" + self.replacingOccurrences(of: "'", with: "'\"'\"'") + "'"
+    }
+}


### PR DESCRIPTION
  - add projectBasePathWithSpaces regression test that renames the fixture .xcodeproj to include a space and verifies selective testing still returns the expected targets
  - introduce String.shellQuoted helper and use it to wrap every interpolated path/branch sent to cd, git, swift package, and similar shell invocations so commands remain valid with spaces or quotes in
    paths
  - ensure SwiftPM manifest parsing and git changeset detection now work reliably for projects whose names contain whitespace
