### PR TITLE
Fix conditional logic for target dependencies

### DIFF
--- a/Sources/DependencyCalculator/PackageMetadata.swift
+++ b/Sources/DependencyCalculator/PackageMetadata.swift
@@ -77,6 +77,10 @@ struct PackageTargetMetadata: Sendable {
                         } else {
                             return TargetIdentity.package(path: path, targetName: depName, testTarget: false)
                         }
+                    } else if let targetDep = dependencyDescription["target"] as? [Any],
+                              let depName = targetDep[0] as? String
+                    {
+                        return TargetIdentity.package(path: path, targetName: depName, testTarget: false)
                     } else {
                         return nil
                     }


### PR DESCRIPTION
First of all, thanks @mikeger for such a great project ❤️ we are evaluating it and find it really useful.

One thing we faced is that in our local packages we define local dependencies via `.target` and the tool was not picking up this.

for example:

```swift
       .target(
            name: "FeatureFlags",
            dependencies: [
                .product(name: "Optimizely", package: "optimizely-swift-sdk"),
                .product(name: "Vexil", package: "Vexil"),
            ],
            path: "Sources/FeatureFlags"
        ),

        .target(
            name: "FeatureFlagsMocks",
            dependencies: [
                .target(name: "FeatureFlags"),
                .product(name: "Vexil", package: "Vexil"),
            ],
            path: "Sources/FeatureFlagsMocks"
        ),
```

So as we defined `.target(name: "FeatureFlags"),` instead of just `"FeatureFlags",` the dependency was not identified.
