### PR TITLE
Support file system synchronized group membership exceptions

### DIFF
--- a/Sources/DependencyCalculator/DependencyGraph.swift
+++ b/Sources/DependencyCalculator/DependencyGraph.swift
@@ -458,8 +458,16 @@ extension WorkspaceInfo {
             let recursiveChildrenFilePaths = ((try? folderPath.recursiveChildren()) ?? [])
                 .filter { $0.isFile }
 
-            paths.append(contentsOf: recursiveChildrenFilePaths.filter { !membershipExceptionPaths.contains($0) })
+            paths.append(contentsOf: recursiveChildrenFilePaths.filter { filePath in
+                !membershipExceptionPaths.contains { filePath.isDescendantOrSelf(of: $0) }
+            })
         }
         return paths
+    }
+}
+
+private extension Path {
+    func isDescendantOrSelf(of path: Path) -> Bool {
+        self == path || string.hasPrefix(path.string + Path.separator)
     }
 }

--- a/Sources/DependencyCalculator/DependencyGraph.swift
+++ b/Sources/DependencyCalculator/DependencyGraph.swift
@@ -429,8 +429,7 @@ extension WorkspaceInfo {
     }
 
     /// Search all files specified in fileSystemSynchronizedGroups.
-    /// Currently, file extensions are note considered at all, so all files in the folder are subject to the search.
-    /// NOTE: FileSystemSynchronizedFileExceptionSet is not suppored yet.
+    /// Currently, file extensions are not considered at all, so all files in the folder are subject to the search.
     ///
     /// ref: https://github.com/tuist/XcodeGraph/pull/108
     /// The implementation of `XcodeGraph` only considers cases where the root is a folder.
@@ -450,7 +449,16 @@ extension WorkspaceInfo {
                 folderPath = group.path.map { Path($0) }
             }
             guard let folderPath else { return }
-            paths.append(contentsOf: (try? folderPath.recursiveChildren()) ?? [])
+
+            let membershipExceptionPaths = (group.exceptions ?? [])
+                .compactMap { $0 as? PBXFileSystemSynchronizedBuildFileExceptionSet }
+                .filter { $0.target.uuid == target.uuid }
+                .flatMap { $0.membershipExceptions ?? [] }
+                .map { folderPath + Path($0) }
+            let recursiveChildrenFilePaths = ((try? folderPath.recursiveChildren()) ?? [])
+                .filter { $0.isFile }
+
+            paths.append(contentsOf: recursiveChildrenFilePaths.filter { !membershipExceptionPaths.contains($0) })
         }
         return paths
     }

--- a/Tests/SelectiveTestingTests/ExampleProject/ExampleProject.xcodeproj/project.pbxproj
+++ b/Tests/SelectiveTestingTests/ExampleProject/ExampleProject.xcodeproj/project.pbxproj
@@ -99,13 +99,14 @@
 			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
 			membershipExceptions = (
 				Path/ExceptionView.swift,
+				Path/ExcludedFolder,
 			);
 			target = 276DB5BA29B144C900E5C615 /* ExampleProject */;
 		};
 /* End PBXFileSystemSynchronizedBuildFileExceptionSet section */
 
 /* Begin PBXFileSystemSynchronizedRootGroup section */
-		095EE0952DB8E35400EACE2E /* DeepFolder */ = {isa = PBXFileSystemSynchronizedRootGroup; exceptions = (095D76502FD30A2E007174DE /* PBXFileSystemSynchronizedBuildFileExceptionSet */, ); explicitFileTypes = {}; explicitFolders = (); path = DeepFolder; sourceTree = "<group>"; };
+		095EE0952DB8E35400EACE2E /* DeepFolder */ = {isa = PBXFileSystemSynchronizedRootGroup; exceptions = (095D76502FD30A2E007174DE /* PBXFileSystemSynchronizedBuildFileExceptionSet */, ); explicitFileTypes = {}; explicitFolders = (Path/ExcludedFolder, ); path = DeepFolder; sourceTree = "<group>"; };
 /* End PBXFileSystemSynchronizedRootGroup section */
 
 /* Begin PBXFrameworksBuildPhase section */

--- a/Tests/SelectiveTestingTests/ExampleProject/ExampleProject.xcodeproj/project.pbxproj
+++ b/Tests/SelectiveTestingTests/ExampleProject/ExampleProject.xcodeproj/project.pbxproj
@@ -94,8 +94,18 @@
 		B24BBDBF2CAD7244005E6DAC /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/Example.strings; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
+/* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
+		095D76502FD30A2E007174DE /* PBXFileSystemSynchronizedBuildFileExceptionSet */ = {
+			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
+			membershipExceptions = (
+				Path/ExceptionView.swift,
+			);
+			target = 276DB5BA29B144C900E5C615 /* ExampleProject */;
+		};
+/* End PBXFileSystemSynchronizedBuildFileExceptionSet section */
+
 /* Begin PBXFileSystemSynchronizedRootGroup section */
-		095EE0952DB8E35400EACE2E /* DeepFolder */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = DeepFolder; sourceTree = "<group>"; };
+		095EE0952DB8E35400EACE2E /* DeepFolder */ = {isa = PBXFileSystemSynchronizedRootGroup; exceptions = (095D76502FD30A2E007174DE /* PBXFileSystemSynchronizedBuildFileExceptionSet */, ); explicitFileTypes = {}; explicitFolders = (); path = DeepFolder; sourceTree = "<group>"; };
 /* End PBXFileSystemSynchronizedRootGroup section */
 
 /* Begin PBXFrameworksBuildPhase section */

--- a/Tests/SelectiveTestingTests/ExampleProject/ExampleProject/DeepFolder/Path/ExceptionView.swift
+++ b/Tests/SelectiveTestingTests/ExampleProject/ExampleProject/DeepFolder/Path/ExceptionView.swift
@@ -1,0 +1,7 @@
+import SwiftUI
+
+struct ExceptionView: View {
+    var body: some View {
+        EmptyView()
+    }
+}

--- a/Tests/SelectiveTestingTests/ExampleProject/ExampleProject/DeepFolder/Path/ExcludedFolder/ExcludedFolderView.swift
+++ b/Tests/SelectiveTestingTests/ExampleProject/ExampleProject/DeepFolder/Path/ExcludedFolder/ExcludedFolderView.swift
@@ -1,0 +1,7 @@
+import SwiftUI
+
+struct ExcludedFolderView: View {
+    var body: some View {
+        EmptyView()
+    }
+}

--- a/Tests/SelectiveTestingTests/SelectiveTestingProjectTests.swift
+++ b/Tests/SelectiveTestingTests/SelectiveTestingProjectTests.swift
@@ -152,6 +152,24 @@ struct SelectiveTestingProjectTests {
     }
 
     @Test
+    func projectDeepFolderMembershipExceptionFolderChange_turbo() async throws {
+        // given
+        let testTool = try IntegrationTestTool()
+        defer { try? testTool.tearDown() }
+
+        let tool = try testTool.createSUT(config: nil,
+                                          basePath: "ExampleProject.xcodeproj",
+                                          turbo: true)
+
+        // when
+        try testTool.changeFile(at: testTool.projectPath + "ExampleProject/DeepFolder/Path/ExcludedFolder/ExcludedFolderView.swift")
+
+        // then
+        let result = try await tool.run()
+        #expect(result == Set<TargetIdentity>())
+    }
+
+    @Test
     func projectTargetDependencyChange_turbo() async throws {
         // given
         let testTool = try IntegrationTestTool()
@@ -205,6 +223,23 @@ struct SelectiveTestingProjectTests {
 
         // when
         try testTool.changeFile(at: testTool.projectPath + "ExampleProject/DeepFolder/Path/ExceptionView.swift")
+
+        // then
+        let result = try await tool.run()
+        #expect(result == Set<TargetIdentity>())
+    }
+
+    @Test
+    func projectDeepFolderMembershipExceptionFolderChange() async throws {
+        // given
+        let testTool = try IntegrationTestTool()
+        defer { try? testTool.tearDown() }
+
+        let tool = try testTool.createSUT(config: nil,
+                                          basePath: "ExampleProject.xcodeproj")
+
+        // when
+        try testTool.changeFile(at: testTool.projectPath + "ExampleProject/DeepFolder/Path/ExcludedFolder/ExcludedFolderView.swift")
 
         // then
         let result = try await tool.run()

--- a/Tests/SelectiveTestingTests/SelectiveTestingProjectTests.swift
+++ b/Tests/SelectiveTestingTests/SelectiveTestingProjectTests.swift
@@ -134,6 +134,24 @@ struct SelectiveTestingProjectTests {
     }
 
     @Test
+    func projectDeepFolderMembershipExceptionPathChange_turbo() async throws {
+        // given
+        let testTool = try IntegrationTestTool()
+        defer { try? testTool.tearDown() }
+
+        let tool = try testTool.createSUT(config: nil,
+                                          basePath: "ExampleProject.xcodeproj",
+                                          turbo: true)
+
+        // when
+        try testTool.changeFile(at: testTool.projectPath + "ExampleProject/DeepFolder/Path/ExceptionView.swift")
+
+        // then
+        let result = try await tool.run()
+        #expect(result == Set<TargetIdentity>())
+    }
+
+    @Test
     func projectTargetDependencyChange_turbo() async throws {
         // given
         let testTool = try IntegrationTestTool()
@@ -174,6 +192,23 @@ struct SelectiveTestingProjectTests {
             testTool.mainProjectTests(),
             testTool.mainProjectUITests(),
         ]))
+    }
+
+    @Test
+    func projectDeepFolderMembershipExceptionPathChange() async throws {
+        // given
+        let testTool = try IntegrationTestTool()
+        defer { try? testTool.tearDown() }
+
+        let tool = try testTool.createSUT(config: nil,
+                                          basePath: "ExampleProject.xcodeproj")
+
+        // when
+        try testTool.changeFile(at: testTool.projectPath + "ExampleProject/DeepFolder/Path/ExceptionView.swift")
+
+        // then
+        let result = try await tool.run()
+        #expect(result == Set<TargetIdentity>())
     }
 
     @Test


### PR DESCRIPTION
This follows up on #48.

# Summary
- Excludes files listed in `PBXFileSystemSynchronizedBuildFileExceptionSet.membershipExceptions`
- Restricts `fileSystemSynchronizedGroupsFiles` to recursive file paths
- Keeps synchronized group directories out of target folder matching

# Notes
The previous synchronized group support used `recursiveChildren()` and treated the returned paths as target inputs. Since `recursiveChildren()` also returns directories, those directories could be registered as folder dependencies. That was not intended: synchronized group handling here should track files, not make every intermediate folder affect the target.